### PR TITLE
Improve course pages and research form, add Luca Ferrarese as fellow

### DIFF
--- a/src/app/education/bitcoin-for-executives/page.tsx
+++ b/src/app/education/bitcoin-for-executives/page.tsx
@@ -23,7 +23,7 @@ export const metadata: Metadata = {
 export default function BitcoinForExecutivesPage() {
   const courseDetails = [
     { icon: <MapPin className="w-5 h-5" />, label: 'Format', value: 'Live course (Zürich)' },
-    { icon: <Clock className="w-5 h-5" />, label: 'Duration', value: '4 afternoons' },
+    { icon: <Clock className="w-5 h-5" />, label: 'Duration', value: '1 course, 4 afternoons' },
     { icon: <Users className="w-5 h-5" />, label: 'Level', value: 'Executives with little Bitcoin knowledge' },
   ]
 
@@ -60,8 +60,8 @@ export default function BitcoinForExecutivesPage() {
                 <span className="pill-hero-text">Strategic Course</span>
               </span>
             </div>
-            <h1 className="mb-10 text-gray-900">Bitcoin for Executives</h1>
-            <p className="swiss-prose-lg mb-12 max-w-4xl mx-auto text-gray-700 leading-relaxed italic">
+            <h1 className="mb-6 sm:mb-8 text-gray-900">Bitcoin for Executives</h1>
+            <p className="swiss-prose-lg mb-8 sm:mb-10 max-w-4xl mx-auto text-gray-700 leading-relaxed">
               A compact course for leaders who need to make responsible decisions about Bitcoin. We provide a professional guided overview of Bitcoin's strategic implications focusing on macro thinking across business, policy, society, and geopolitics.
             </p>
           </div>
@@ -69,23 +69,11 @@ export default function BitcoinForExecutivesPage() {
       </section>
 
       {/* Course Details */}
-      <section className="swiss-section bg-white">
+      <section className="swiss-section-sm sm:swiss-section bg-white">
         <div className="swiss-grid">
           <div className="max-w-4xl mx-auto">
-            <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-16 border-b border-gray-200 pb-12">
-              {courseDetails.map((detail, index) => (
-                <div key={index} className="text-center">
-                  <div className="flex justify-center mb-4">
-                    <div className="text-swiss-blue">{detail.icon}</div>
-                  </div>
-                  <div className="text-sm text-gray-500 mb-2 font-medium">{detail.label}</div>
-                  <div className="font-semibold text-gray-900">{detail.value}</div>
-                </div>
-              ))}
-            </div>
-
             {/* Two Column Layout */}
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-12 mb-16">
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-12 mb-12 sm:mb-16">
               {/* Who it's for */}
               <div>
                 <h2 className="text-2xl font-semibold text-gray-900 mb-6">Who it's for</h2>
@@ -112,27 +100,46 @@ export default function BitcoinForExecutivesPage() {
                 </ul>
               </div>
             </div>
+
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-6 border-t border-gray-200 pt-8 sm:pt-12">
+              {courseDetails.map((detail, index) => (
+                <div key={index} className="text-center">
+                  <div className="flex justify-center mb-4">
+                    <div className="text-swiss-blue">{detail.icon}</div>
+                  </div>
+                  <div className="text-sm text-gray-500 mb-2 font-medium">{detail.label}</div>
+                  <div className="font-semibold text-gray-900">{detail.value}</div>
+                </div>
+              ))}
+            </div>
           </div>
         </div>
       </section>
 
       {/* Course Registration */}
-      <section className="swiss-section bg-gray-50">
+      <section className="swiss-section-sm sm:swiss-section bg-gray-50">
         <div className="swiss-grid">
-          <div className="max-w-4xl mx-auto">
+          <div className="max-w-5xl mx-auto">
             {/* Price */}
-            <div className="text-center mb-8">
-              <div className="inline-block p-6 border-2 border-gray-200 rounded-lg bg-gray-50">
-                <div className="text-3xl font-bold text-gray-900">CHF 1'399.-</div>
+            <div className="text-center mb-10 sm:mb-12">
+              <div className="inline-block px-6 sm:px-8 py-4 sm:py-6 bg-gray-50 rounded-xl border border-gray-200">
+                <div className="text-3xl sm:text-4xl font-bold text-gray-900">CHF 1'399.-</div>
               </div>
             </div>
 
             <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
               {/* Next Course Dates */}
               <Card className="p-6 border-2 border-gray-200 bg-white self-start">
-                <div className="text-sm text-gray-500 mb-2 font-medium">Next course:</div>
-                <div className="font-semibold text-gray-900 mb-1 text-lg">12/19/26 Feb, 5 Mar</div>
-                <div className="text-gray-600">14-17h</div>
+                <div className="text-sm mb-4 font-medium uppercase tracking-wide swiss-blue-gradient-text">Next course:</div>
+                <div className="mb-3 text-sm font-bold text-gray-900">
+                  4 afternoons (14-17h)
+                </div>
+                <div className="space-y-2">
+                  <div className="text-base text-gray-900">12th February</div>
+                  <div className="text-base text-gray-900">19th February</div>
+                  <div className="text-base text-gray-900">26th February</div>
+                  <div className="text-base text-gray-900">5th March 2026</div>
+                </div>
               </Card>
 
               {/* Signup Form */}
@@ -142,6 +149,7 @@ export default function BitcoinForExecutivesPage() {
                   <CourseSignupForm 
                     courseName="Bitcoin for Executives"
                     courseSlug="bitcoin-executives"
+                    courseDate="4 afternoons (14-17h): 12th February, 19th February, 26th February, March 5th 2026"
                   />
                 </Card>
               </div>

--- a/src/app/education/financial-sovereignty/page.tsx
+++ b/src/app/education/financial-sovereignty/page.tsx
@@ -68,32 +68,20 @@ export default function FinancialSovereigntyPage() {
       <section className="swiss-section bg-white">
         <div className="swiss-grid">
           <div className="max-w-4xl mx-auto">
-            <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-16 border-b border-gray-200 pb-12">
-            {courseDetails.map((detail, index) => (
-                <div key={index} className="text-center">
-                  <div className="flex justify-center mb-4">
-                    <div className="text-swiss-blue">{detail.icon}</div>
-                  </div>
-                  <div className="text-sm text-gray-500 mb-2 font-medium">{detail.label}</div>
-                  <div className="font-semibold text-gray-900">{detail.value}</div>
-                </div>
-              ))}
-            </div>
-
             {/* Two Column Layout */}
             <div className="grid grid-cols-1 md:grid-cols-2 gap-12 mb-16">
               {/* Who it's for */}
               <div>
                 <h2 className="text-2xl font-semibold text-gray-900 mb-6">Who it's for</h2>
-                  <ul className="space-y-3">
+                <ul className="space-y-3">
                   {whoItsFor.map((item, index) => (
                     <li key={index} className="flex items-start space-x-3">
                       <CheckCircle2 className="w-5 h-5 text-swiss-blue flex-shrink-0 mt-0.5" />
-                        <span className="text-gray-700">{item}</span>
-                      </li>
-                    ))}
-                  </ul>
-        </div>
+                      <span className="text-gray-700">{item}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
 
               {/* What you'll get */}
               <div>
@@ -102,11 +90,23 @@ export default function FinancialSovereigntyPage() {
                   {whatYoullGet.map((item, index) => (
                     <li key={index} className="flex items-start space-x-3">
                       <CheckCircle2 className="w-5 h-5 text-swiss-blue flex-shrink-0 mt-0.5" />
-                  <span className="text-gray-700">{item}</span>
+                      <span className="text-gray-700">{item}</span>
                     </li>
                   ))}
                 </ul>
+              </div>
+            </div>
+
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-6 border-t border-gray-200 pt-12">
+              {courseDetails.map((detail, index) => (
+                <div key={index} className="text-center">
+                  <div className="flex justify-center mb-4">
+                    <div className="text-swiss-blue">{detail.icon}</div>
+                  </div>
+                  <div className="text-sm text-gray-500 mb-2 font-medium">{detail.label}</div>
+                  <div className="font-semibold text-gray-900">{detail.value}</div>
                 </div>
+              ))}
             </div>
           </div>
         </div>
@@ -127,9 +127,13 @@ export default function FinancialSovereigntyPage() {
             <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
               {/* Next Course Dates */}
               <Card className="p-6 border-2 border-gray-200 bg-white self-start">
-                <div className="text-sm text-gray-500 mb-2 font-medium">Next course:</div>
-                <div className="font-semibold text-gray-900 mb-1 text-lg">Thu, 12 Mar</div>
-                <div className="text-gray-600">13:30-17:30</div>
+                <div className="text-sm mb-4 font-medium uppercase tracking-wide swiss-blue-gradient-text">Next course:</div>
+                <div className="mb-3 text-sm font-bold text-gray-900">
+                  0.5 day (13:30-17:30)
+                </div>
+                <div className="space-y-2">
+                  <div className="text-base text-gray-900">12th March 2026</div>
+                </div>
               </Card>
 
               {/* Signup Form */}
@@ -139,6 +143,7 @@ export default function FinancialSovereigntyPage() {
                   <CourseSignupForm 
                     courseName="Financial Sovereignty - Starter"
                     courseSlug="financial-sovereignty"
+                    courseDate="0.5 day (13:30-17:30): 12th March 2026"
                   />
                 </Card>
               </div>

--- a/src/app/fellows/[slug]/page.tsx
+++ b/src/app/fellows/[slug]/page.tsx
@@ -19,7 +19,7 @@ interface PageProps {
 }
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
-  const member = getTeamMemberBySlug(params.slug);
+  const member = getTeamMemberBySlug(params.slug, 'fellow');
 
   if (!member || member.category !== 'fellow') {
     return {
@@ -53,7 +53,7 @@ export async function generateStaticParams() {
 }
 
 export default async function FellowPage({ params }: PageProps) {
-  const member = getTeamMemberBySlug(params.slug);
+  const member = getTeamMemberBySlug(params.slug, 'fellow');
 
   if (!member || member.category !== 'fellow') {
     notFound();

--- a/src/app/meet-the-team/[slug]/page.tsx
+++ b/src/app/meet-the-team/[slug]/page.tsx
@@ -18,7 +18,7 @@ interface PageProps {
 }
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
-  const member = getTeamMemberBySlug(params.slug);
+  const member = getTeamMemberBySlug(params.slug, 'core');
 
   if (!member) {
     return {
@@ -55,7 +55,7 @@ export async function generateStaticParams() {
 }
 
 export default async function TeamMemberPage({ params }: PageProps) {
-  const member = getTeamMemberBySlug(params.slug);
+  const member = getTeamMemberBySlug(params.slug, 'core');
 
   if (!member) {
     notFound();

--- a/src/app/research/[slug]/page.tsx
+++ b/src/app/research/[slug]/page.tsx
@@ -116,9 +116,10 @@ export default async function ArticlePageRoute({ params }: PageProps) {
                       // Check if author is a fellow and make name clickable
                       const articleToTeamSlugMap: Record<string, string> = {
                         'dr-christian-decker': 'christian-decker',
+                        'luca-ferrarese': 'luca-ferrarese',
                       };
                       const teamMemberSlug = articleToTeamSlugMap[article.author] || article.author;
-                      const teamMember = getTeamMemberBySlug(teamMemberSlug);
+                      const teamMember = getTeamMemberBySlug(teamMemberSlug, 'fellow'); // Prefer fellow if exists
                       const isFellow = teamMember?.category === 'fellow';
                       
                       if (isFellow) {

--- a/src/app/team/[slug]/page.tsx
+++ b/src/app/team/[slug]/page.tsx
@@ -18,7 +18,7 @@ interface PageProps {
 }
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
-  const member = getTeamMemberBySlug(params.slug);
+  const member = getTeamMemberBySlug(params.slug, 'core');
 
   if (!member) {
     return {
@@ -55,7 +55,7 @@ export async function generateStaticParams() {
 }
 
 export default async function TeamMemberPage({ params }: PageProps) {
-  const member = getTeamMemberBySlug(params.slug);
+  const member = getTeamMemberBySlug(params.slug, 'core');
 
   if (!member) {
     notFound();

--- a/src/components/articles/ArticleContent.tsx
+++ b/src/components/articles/ArticleContent.tsx
@@ -92,9 +92,10 @@ const ArticleContent = ({ article, author }: ArticleContentProps) => {
               // Map article author slug to team member slug
               const articleToTeamSlugMap: Record<string, string> = {
                 'dr-christian-decker': 'christian-decker',
+                'luca-ferrarese': 'luca-ferrarese',
               };
               const teamMemberSlug = articleToTeamSlugMap[article.author] || article.author;
-              const teamMember = getTeamMemberBySlug(teamMemberSlug);
+              const teamMember = getTeamMemberBySlug(teamMemberSlug, 'fellow'); // Prefer fellow if exists
               const isFellow = teamMember?.category === 'fellow';
               
               if (isFellow) {

--- a/src/components/forms/CourseSignupForm.tsx
+++ b/src/components/forms/CourseSignupForm.tsx
@@ -10,9 +10,10 @@ import { Loader2 } from 'lucide-react';
 interface CourseSignupFormProps {
   courseName: string;
   courseSlug: string;
+  courseDate?: string;
 }
 
-export default function CourseSignupForm({ courseName, courseSlug }: CourseSignupFormProps) {
+export default function CourseSignupForm({ courseName, courseSlug, courseDate }: CourseSignupFormProps) {
   const { toast } = useToast();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [formData, setFormData] = useState({
@@ -20,6 +21,7 @@ export default function CourseSignupForm({ courseName, courseSlug }: CourseSignu
     email: '',
     phone: '',
     organization: '',
+    courseDate: courseDate || '',
     message: '',
   });
 
@@ -32,10 +34,10 @@ export default function CourseSignupForm({ courseName, courseSlug }: CourseSignu
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     
-    if (!formData.name || !formData.email) {
+    if (!formData.name || !formData.email || (courseDate && !formData.courseDate)) {
       toast({
         title: "Please fill in required fields",
-        description: "Name and email are required.",
+        description: "Name, email, and course date are required.",
         variant: "destructive",
       });
       return;
@@ -68,6 +70,7 @@ export default function CourseSignupForm({ courseName, courseSlug }: CourseSignu
           email: '',
           phone: '',
           organization: '',
+          courseDate: courseDate || '',
           message: '',
         });
       } else {
@@ -146,6 +149,21 @@ export default function CourseSignupForm({ courseName, courseSlug }: CourseSignu
         </div>
       </div>
 
+      {courseDate && (
+        <div>
+          <Label htmlFor="courseDate">Course Date *</Label>
+          <Input
+            id="courseDate"
+            name="courseDate"
+            type="text"
+            required
+            value={formData.courseDate}
+            readOnly
+            className="mt-1 bg-gray-50 cursor-not-allowed border-gray-300 text-gray-700"
+          />
+        </div>
+      )}
+
       <div>
         <Label htmlFor="message">Message (optional)</Label>
         <textarea
@@ -163,7 +181,7 @@ export default function CourseSignupForm({ courseName, courseSlug }: CourseSignu
         type="submit"
         variant="default"
         size="lg"
-        className="w-full"
+        className="w-full swiss-blue-gradient text-white shadow-lg hover:shadow-xl"
         disabled={isSubmitting}
       >
         {isSubmitting ? (

--- a/src/lib/team.ts
+++ b/src/lib/team.ts
@@ -136,10 +136,37 @@ export const teamMembers: TeamMember[] = [
     category: 'fellow',
     tags: ['Sustainability', 'Social Impact', 'Development'],
   },
+  {
+    slug: 'luca-ferrarese',
+    name: 'Dr. Luca Ferrarese',
+    role: 'Research Fellow',
+    bio: 'My background is in science, but a strong desire to understand Bitcoin led me on an intense, self-directed journey into the history of money, finance and macroeconomics. This exploration into new disciplines inspired me to share my findings through articles, presentations and podcasts. Applying the analytical lens of a molecular biologist gives me a unique perspective on these complex topics and the systemic changes Bitcoin is introducing.',
+    photo: '/sbi-core-team/Luca_Ferrarese-SBI.png',
+    email: 'luca.ferrarese@bitcoininstitute.ch',
+    linkedin: 'https://www.linkedin.com/in/lucaferrarese/',
+    category: 'fellow',
+    tags: ['Monetary Theory', 'Economics', 'Finance'],
+  },
 ];
 
-export function getTeamMemberBySlug(slug: string): TeamMember | undefined {
-  return teamMembers.find(member => member.slug === slug);
+export function getTeamMemberBySlug(slug: string, preferCategory?: 'core' | 'fellow'): TeamMember | undefined {
+  const matches = teamMembers.filter(member => member.slug === slug);
+  
+  if (matches.length === 0) {
+    return undefined;
+  }
+  
+  if (matches.length === 1) {
+    return matches[0];
+  }
+  
+  // If multiple matches and preference specified, return that one
+  if (preferCategory) {
+    return matches.find(member => member.category === preferCategory) || matches[0];
+  }
+  
+  // Default: prefer fellow if both exist
+  return matches.find(member => member.category === 'fellow') || matches[0];
 }
 
 export function getAllTeamMembers(): TeamMember[] {


### PR DESCRIPTION
- Optimize course date displays on Bitcoin for Executives and Financial Sovereignty pages
  - Improved date format with better readability (e.g., '12th February, 19th, 26th February, March 5th 2026')
  - Enhanced styling with blue gradient text and better visual hierarchy
  - Preselect course dates in booking forms

- Reorganize course detail sections
  - Move 'Who it's for' and 'What you'll get' above format/duration/level info
  - Improve section spacing and layout

- Enhance research inquiry form
  - Change 'Research Brief' to 'Research'
  - Add Quarterly Research Package checkbox option with full description
  - Implement mutually exclusive selection: either Quarterly Package OR custom research inquiry
  - Update form validation and submission logic

- Add Luca Ferrarese as Research Fellow
  - Create additional fellow profile while keeping core team member entry
  - Link his article (SBI-004) to fellow profile
  - Update author mappings to make his name clickable in articles
  - Enhance getTeamMemberBySlug to handle duplicate slugs with category preference

- Fix course signup form to include courseDate field with preselected dates