### PR TITLE
Fix banner positioning and add 2-week dismissal expiration

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -65,7 +65,7 @@ export default function RootLayout({
         <OrganizationSchema />
         <Providers>
           <NextEventBanner />
-          <div className="min-h-screen flex flex-col">
+          <div className="min-h-screen flex flex-col" style={{ paddingTop: 'var(--banner-height, 0px)' }}>
             <Header />
             <main className="flex-1">
               {children}

--- a/src/components/sections/NextEventBanner.tsx
+++ b/src/components/sections/NextEventBanner.tsx
@@ -6,22 +6,52 @@ import Link from 'next/link';
 import { cn } from '@/lib/utils';
 
 const EVENT_BANNER_KEY = 'sbi-next-event-banner-dismissed';
+const DISMISSAL_DURATION_MS = 14 * 24 * 60 * 60 * 1000; // 2 weeks in milliseconds
 
 export default function NextEventBanner() {
   const [isVisible, setIsVisible] = useState(false);
 
   useEffect(() => {
     // Check if user has dismissed the banner
-    const isDismissed = localStorage.getItem(EVENT_BANNER_KEY);
-    if (!isDismissed) {
-      // Show banner immediately
+    const dismissedData = localStorage.getItem(EVENT_BANNER_KEY);
+    if (!dismissedData) {
+      // Show banner immediately if never dismissed
       setIsVisible(true);
+    } else {
+      try {
+        const dismissedTimestamp = parseInt(dismissedData, 10);
+        const now = Date.now();
+        const timeSinceDismissal = now - dismissedTimestamp;
+        
+        // Show banner again if 2 weeks have passed
+        if (timeSinceDismissal >= DISMISSAL_DURATION_MS) {
+          localStorage.removeItem(EVENT_BANNER_KEY);
+          setIsVisible(true);
+        }
+      } catch (error) {
+        // If parsing fails, show the banner
+        localStorage.removeItem(EVENT_BANNER_KEY);
+        setIsVisible(true);
+      }
     }
   }, []);
 
+  useEffect(() => {
+    // Add/remove CSS variable to account for banner height
+    if (isVisible && typeof document !== 'undefined') {
+      document.documentElement.style.setProperty('--banner-height', '56px');
+      if (window.matchMedia('(min-width: 640px)').matches) {
+        document.documentElement.style.setProperty('--banner-height', '64px');
+      }
+    } else if (typeof document !== 'undefined') {
+      document.documentElement.style.setProperty('--banner-height', '0px');
+    }
+  }, [isVisible]);
+
   const handleDismiss = () => {
     setIsVisible(false);
-    localStorage.setItem(EVENT_BANNER_KEY, 'true');
+    // Store timestamp of dismissal
+    localStorage.setItem(EVENT_BANNER_KEY, Date.now().toString());
   };
 
   if (!isVisible) return null;
@@ -29,12 +59,12 @@ export default function NextEventBanner() {
   return (
     <div 
       className={cn(
-        "sticky top-0 z-[60] transition-all duration-500 ease-in-out",
+        "fixed top-0 left-0 right-0 z-[60] transition-all duration-500 ease-in-out",
         isVisible ? "translate-y-0 opacity-100" : "-translate-y-full opacity-0"
       )}
     >
-      {/* Backdrop - subtle orange */}
-      <div className="bg-gradient-to-r from-orange-50/98 via-orange-50/95 to-orange-50/98 backdrop-blur-sm border-b border-orange-100">
+      {/* Backdrop - white background */}
+      <div className="bg-white border-b border-orange-100">
         {/* Content */}
         <div className="swiss-grid py-3 sm:py-4">
           <div className="max-w-6xl mx-auto">


### PR DESCRIPTION
- Change banner background to solid white (from transparent orange)
- Change positioning from sticky to fixed (stays above navbar always)
- Add dynamic padding-top using CSS variable to push navbar below banner
- Update dismissal logic to expire after 2 weeks (instead of permanent)
- Store dismissal timestamp to track when to show banner again