### PR TITLE
Set new dates (plus: 1 point to discuss)

### DIFF
--- a/src/lib/courses.ts
+++ b/src/lib/courses.ts
@@ -6,9 +6,9 @@ export interface CourseOffering {
 
 export const bitcoinForExecutivesCourses: CourseOffering[] = [
   {
-    id: "b4x-feb-2026",
-    timeDescription: "Four afternoons (14-17h)",
-    dates: ["12 February 2026", "19 February 2026", "26 February 2026", "05 March 2026"]
+    id: "b4x-mar-2026",
+    timeDescription: "Two days (09:00-16:30)",
+    dates: ["12+13 March 2026", "16+17 April 2026"]
   }
 ];
 
@@ -16,8 +16,8 @@ export const bitcoinForExecutivesCourses: CourseOffering[] = [
 export const FinSovCourses: CourseOffering[] = [
   {
     id: "fs1-mar-2026",
-    timeDescription: "Half a day (13:30-17:30h)",
-    dates: ["12 March 2026"]
+    timeDescription: "Half a day (13:30-17:30)",
+    dates: ["20 March 2026"]
   }
 ];
 


### PR DESCRIPTION
One complication comes from switching from 4x1/2d to 2x1d course format for the B4X course.

Before, one B4X course was defined by 4 dates. Now I entered two double-dates for TWO course, not one. Website display may be ok, but the forms may not display it correctly. Coudl you please check/verify, @dannybabbev ? Thanks.