### PR TITLE
#NeedsResearch: Update NextEventBanner functionality

### DIFF
--- a/src/components/sections/NextEventBanner.tsx
+++ b/src/components/sections/NextEventBanner.tsx
@@ -24,6 +24,7 @@ export default function NextEventBanner() {
         const timeSinceDismissal = now - dismissedTimestamp;
         
         // Show banner again if 2 weeks have passed
+        // #TODO: is it really auto-switching on after 2 weeks? Does not make sense. Should be switched on/off with a flag (and maybe stay ON until the webinar took place)
         if (timeSinceDismissal >= DISMISSAL_DURATION_MS) {
           localStorage.removeItem(EVENT_BANNER_KEY);
           setIsVisible(true);


### PR DESCRIPTION
It seems to reappear automaticlly after 2 weeks, withtou anything else. Not useful like this IMO. Should be swichted on/off with a flag somewhere and then disappear for good when a webinar took place. or we levae all automagic out and just have an on/off switch.