### PR TITLE
fix: add education background image to course hero sections

### DIFF
--- a/src/app/education/bitcoin-for-executives/page.tsx
+++ b/src/app/education/bitcoin-for-executives/page.tsx
@@ -54,11 +54,19 @@ export default function BitcoinForExecutivesPage() {
     <div className="min-h-screen">
       {/* Hero */}
       <section className="swiss-hero swiss-gradient relative overflow-hidden">
-        <div className="absolute inset-0 swiss-blue-gradient-hero"></div>
-        <div className="swiss-grid relative">
+        {/* Background Image */}
+        <div
+          className="absolute inset-0 bg-cover bg-right-top md:bg-top bg-no-repeat"
+          style={{
+            backgroundImage: 'url(/SBI-education-hero.jpg)',
+          }}
+        />
+        {/* White overlay for strong fade effect - 80% opacity (image at ~20% visibility) */}
+        <div className="absolute inset-0 bg-white/80"></div>
+        <div className="swiss-grid relative z-10">
           <div className="max-w-5xl mx-auto text-center">
             <div className="mb-8">
-              <span className="pill-hero mb-6">
+              <span className="pill-hero mb-6 bg-white/90 backdrop-blur-sm">
                 <span className="mr-2">💼</span>
                 <span className="pill-hero-text">Strategic Course</span>
               </span>

--- a/src/app/education/financial-sovereignty/page.tsx
+++ b/src/app/education/financial-sovereignty/page.tsx
@@ -49,11 +49,19 @@ export default function FinancialSovereigntyPage() {
     <div className="min-h-screen">
       {/* Hero */}
       <section className="swiss-hero swiss-gradient relative overflow-hidden">
-        <div className="absolute inset-0 swiss-blue-gradient-hero"></div>
-        <div className="swiss-grid relative">
+        {/* Background Image */}
+        <div
+          className="absolute inset-0 bg-cover bg-right-top md:bg-top bg-no-repeat"
+          style={{
+            backgroundImage: 'url(/SBI-education-hero.jpg)',
+          }}
+        />
+        {/* White overlay for strong fade effect - 80% opacity (image at ~20% visibility) */}
+        <div className="absolute inset-0 bg-white/80"></div>
+        <div className="swiss-grid relative z-10">
           <div className="max-w-5xl mx-auto text-center">
             <div className="mb-8">
-              <span className="pill-hero mb-6">
+              <span className="pill-hero mb-6 bg-white/90 backdrop-blur-sm">
                 <span className="mr-2">🔐</span>
                 <span className="pill-hero-text">Hands-On Course</span>
               </span>


### PR DESCRIPTION
Apply the same background image (SBI-education-hero.jpg) and white overlay from /education to the bitcoin-for-executives and financial-sovereignty course pages for visual consistency.

Closes #44

Generated with [Claude Code](https://claude.ai/code)