### PR TITLE
chore: remove emoji pill slogans, "More to come" box, and Mission/Vision cards

### DIFF
--- a/src/app/education/page.tsx
+++ b/src/app/education/page.tsx
@@ -33,12 +33,6 @@ export default function CoursesPage() {
         <div className="absolute inset-0 bg-white/80"></div>
         <div className="swiss-grid relative z-10">
           <div className="max-w-5xl mx-auto text-center">
-            <div className="mb-8">
-              <span className="pill-hero mb-6 bg-white/90 backdrop-blur-sm">
-                <span className="mr-2">🎓</span>
-                <span className="pill-hero-text">Professional Education</span>
-              </span>
-            </div>
             <h1>Executive Education</h1>
             <p className="swiss-prose-lg mb-12 max-w-4xl mx-auto text-gray-700 leading-relaxed">
               Build the competency your organization needs to navigate the Bitcoin age confidently.

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -36,12 +36,6 @@ const About = () => {
         <div className="absolute inset-0 swiss-blue-gradient-hero"></div>
         <div className="swiss-grid relative">
           <div className="max-w-5xl mx-auto text-center">
-            <div className="mb-8">
-              <span className="pill-hero mb-6">
-                <span className="mr-2">🏛️</span>
-                <span className="pill-hero-text">Independent Research & Analysis</span>
-              </span>
-            </div>
             <h1 className="mb-10 text-gray-900">Bitcoin's Natural Alignment with Switzerland</h1>
             <p className="swiss-prose-lg mb-16 max-w-4xl mx-auto text-gray-700 leading-relaxed">
               Bitcoin's and Swiss values align naturally, creating unique opportunities for Switzerland's future.

--- a/src/pages/Fellowship.tsx
+++ b/src/pages/Fellowship.tsx
@@ -14,12 +14,6 @@ const Fellowship = () => {
         <div className="absolute inset-0 swiss-blue-gradient-hero"></div>
         <div className="swiss-grid relative">
           <div className="max-w-5xl mx-auto text-center">
-            <div className="mb-8">
-              <span className="pill-hero mb-6">
-                <span className="mr-2">🎓</span>
-                <span className="pill-hero-text">Research Network</span>
-              </span>
-            </div>
             <h1 className="mb-10 text-gray-900">Join Switzerland's leading network of Bitcoin experts shaping the future of money.</h1>
             <p className="swiss-prose-lg mb-12 max-w-4xl mx-auto text-gray-700 leading-relaxed">
               The SBI Fellowship brings together independent researchers and practitioners across six critical domains: Access & Agency, Energy & Climate, Finance & Economics, Markets & Geopolitics, Strategy & Policy, and Technology & Innovation. Our fellows produce rigorous, evidence-based analysis on Bitcoin's strategic implications for Switzerland—without the hype.

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -88,12 +88,6 @@ const Home = () => {
         <div className="absolute inset-0 bg-white/80"></div>
         <div className="swiss-grid relative z-10">
           <div className="max-w-5xl mx-auto text-center">
-            <div className="mb-8">
-              <span className="pill-hero mb-6 bg-white/90 backdrop-blur-sm">
-                <span className="mr-2">🇨🇭</span>
-                <span className="pill-hero-text">Switzerland's Independent Bitcoin Think Tank</span>
-              </span>
-            </div>
             <h1 className="text-gray-900">Empowering leaders for the Bitcoin age</h1>
             <p className="swiss-prose-lg mb-12 max-w-4xl mx-auto text-gray-700">
               Executive education and independent research to navigate the transition to sound digital money.
@@ -179,25 +173,6 @@ const Home = () => {
             ))}
           </div>
 
-          {/* More to Come Card */}
-          <div className="mt-12 max-w-4xl mx-auto">
-            <div className="card-general p-8 bg-gradient-to-br from-gray-50 to-white border-2 border-gray-200">
-              <div className="text-center">
-                <h3 className="text-2xl font-semibold mb-3 text-gray-900">More to come in 2026!</h3>
-                <p className="text-gray-600 mb-6 text-base">
-                  We plan to expand our offering with much more. Stay tuned!
-                </p>
-                <CTAButton 
-                  variant="secondary" 
-                  size="lg" 
-                  href="/webinar"
-                  className="mx-auto"
-                >
-                  Tell me more
-                </CTAButton>
-              </div>
-            </div>
-          </div>
         </div>
       </section>
 

--- a/src/pages/Research.tsx
+++ b/src/pages/Research.tsx
@@ -76,12 +76,6 @@ const Research = () => {
         <div className="absolute inset-0 bg-white/80"></div>
         <div className="swiss-grid relative z-10">
           <div className="max-w-5xl mx-auto text-center">
-            <div className="mb-8">
-              <span className="pill-hero mb-6 bg-white/90 backdrop-blur-sm">
-                <span className="mr-2">🧠</span>
-                <span className="pill-hero-text">Strategic Intelligence</span>
-              </span>
-            </div>
             <h1>Bitcoin Intelligence</h1>
             <p className="swiss-prose-lg mb-12 max-w-4xl mx-auto text-gray-700 leading-relaxed">
               We cover all strategic aspects of Bitcoin and deliver actionable insights for your decision-making on a regular basis. Stay ahead with Bitcoin intelligence that matters.

--- a/src/pages/StrategicSpeaking.tsx
+++ b/src/pages/StrategicSpeaking.tsx
@@ -17,12 +17,6 @@ export default function StrategicSpeaking() {
         <div className="absolute inset-0 bg-white/80"></div>
         <div className="swiss-grid relative z-10">
           <div className="max-w-5xl mx-auto text-center">
-            <div className="mb-8">
-              <span className="pill-hero mb-6 bg-white/90 backdrop-blur-sm">
-                <span className="mr-2">🎤</span>
-                <span className="pill-hero-text">Strategic Speaking</span>
-              </span>
-            </div>
             <h1>Bitcoin Keynotes & Presentations</h1>
             <p className="swiss-prose-lg mb-12 max-w-4xl mx-auto text-gray-700 leading-relaxed">
               Our team shares insights on Bitcoin's strategic implications for businesses, organizations, and policy audiences. 

--- a/src/pages/Team.tsx
+++ b/src/pages/Team.tsx
@@ -14,12 +14,6 @@ const Team = () => {
         <div className="absolute inset-0 swiss-blue-gradient-hero"></div>
         <div className="swiss-grid relative">
           <div className="max-w-5xl mx-auto text-center">
-            <div className="mb-8">
-              <span className="pill-hero mb-6">
-                <span className="mr-2">👥</span>
-                <span className="pill-hero-text">World-Class Expertise</span>
-              </span>
-            </div>
             <h1 className="mb-10 text-gray-900">Meet the Team</h1>
             <p className="swiss-prose-lg mb-12 max-w-4xl mx-auto text-gray-700 leading-relaxed">
               The Institute blends academic rigor with practical expertise to empower leaders 
@@ -56,41 +50,6 @@ const Team = () => {
                 <p className="swiss-blue-gradient-text font-semibold mb-6 text-lg">{member.role}</p>
               </Link>
             ))}
-          </div>
-        </div>
-      </section>
-
-      {/* Vision & Mission */}
-      <section className="swiss-section bg-white">
-        <div className="swiss-grid">
-          <div className="max-w-5xl mx-auto">
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
-              {/* Vision */}
-              <div className="card-general card-gradient-hover p-8 h-full">
-                <div className="mb-6">
-                  <div className="w-16 h-16 bg-gradient-to-br from-swiss-blue/10 to-swiss-blue/5 rounded-2xl flex items-center justify-center mb-4">
-                    <span className="text-3xl">👁️</span>
-                  </div>
-                  <h3 className="text-2xl font-semibold mb-4 text-gray-900">Vision</h3>
-                </div>
-                <p className="swiss-prose-lg text-gray-700 leading-relaxed">
-                  A prosperous world where sound money enables freedom, peace, and sustainability.
-                </p>
-              </div>
-
-              {/* Mission */}
-              <div className="card-general card-gradient-hover p-8 h-full">
-                <div className="mb-6">
-                  <div className="w-16 h-16 bg-gradient-to-br from-swiss-blue/10 to-swiss-blue/5 rounded-2xl flex items-center justify-center mb-4">
-                    <span className="text-3xl">🎯</span>
-                  </div>
-                  <h3 className="text-2xl font-semibold mb-4 text-gray-900">Mission</h3>
-                </div>
-                <p className="swiss-prose-lg text-gray-700 leading-relaxed">
-                  We equip Swiss decision-makers in business, government, and civil society with rigorous research and executive education to navigate Bitcoin's strategic implications – for their organizations and for Switzerland.
-                </p>
-              </div>
-            </div>
           </div>
         </div>
       </section>

--- a/src/pages/WhyBitcoin.tsx
+++ b/src/pages/WhyBitcoin.tsx
@@ -77,12 +77,6 @@ const WhyBitcoin = () => {
         <div className="absolute inset-0 swiss-blue-gradient-hero"></div>
         <div className="swiss-grid relative">
           <div className="max-w-5xl mx-auto text-center">
-            <div className="mb-8">
-              <span className="pill-hero mb-6">
-                <span className="mr-2">₿</span>
-                <span className="pill-hero-text">Fundamental Properties</span>
-              </span>
-            </div>
             <h1 className="mb-10 text-gray-900">Why Bitcoin</h1>
             <p className="swiss-prose-lg mb-12 max-w-4xl mx-auto text-gray-700 leading-relaxed">
               Several fundamental properties render Bitcoin unique in the crypto and fiat world alike. Over the years, they have resulted in three real-world outcomes for Bitcoin that make it stand out from all other forms of money, digital or not. If you have not, you really should start studying Bitcoin. If not for yourself, then for your children, because there is a real chance that Bitcoin will outlive you.


### PR DESCRIPTION
Removes blue-gradient pill-hero emoji labels from all page heroes, the "More to come in 2026!" box from the landing page, and Mission/Vision cards from the team page.

Closes #50

Generated with [Claude Code](https://claude.ai/code)