### PR TITLE
cleanup: price tags & domains page (issue #111)

### DIFF
--- a/src/app/domains/DomainsClient.tsx
+++ b/src/app/domains/DomainsClient.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import Link from 'next/link';
-import { ArrowLeft, ArrowRight } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 
 const Domains = () => {
@@ -75,10 +74,9 @@ const Domains = () => {
         <div className="absolute inset-0 swiss-blue-gradient-hero"></div>
         <div className="swiss-grid relative">
           <div className="max-w-5xl mx-auto text-center">
-            <h1 className="mb-6 text-gray-900">Six Research Domains</h1>
+            <h1 className="mb-6 text-gray-900">SBI Research Domains</h1>
             <p className="swiss-prose-lg mb-8 max-w-4xl mx-auto text-gray-700 leading-relaxed">
-              Our research spans six interconnected domains that capture Bitcoin's full strategic significance
-              for Switzerland's leadership in the global monetary system.
+              With the SBI domain framework, we aim to capture all societal domains of strategic relevance that we expect to be affected by Bitcoin in the future. Click on the circle to learn more.
             </p>
           </div>
         </div>
@@ -122,16 +120,6 @@ const Domains = () => {
                   </div>
                 </div>
 
-                {/* Article Link */}
-                <div className="mt-8">
-                  <Link
-                    href={domain.articleLink}
-                    className="link-research inline-flex items-center text-sm font-semibold group"
-                  >
-                    <span>Read related article</span>
-                    <ArrowRight className="w-4 h-4 ml-2 group-hover:translate-x-1 transition-transform" />
-                  </Link>
-                </div>
               </article>
             ))}
           </div>

--- a/src/app/education/bitcoin-for-executives/page.tsx
+++ b/src/app/education/bitcoin-for-executives/page.tsx
@@ -124,11 +124,6 @@ export default function BitcoinForExecutivesPage() {
       <section className="py-8 sm:py-10 bg-gray-50">
         <div className="swiss-grid">
           <div className="max-w-5xl mx-auto">
-            <div className="flex justify-center mb-10">
-              <div className="inline-block px-6 py-4 border-2 border-gray-200 rounded-xl bg-gray-50 text-center">
-                <div className="text-3xl font-bold text-gray-900 mb-1">CHF 5'999.-</div>
-              </div>
-            </div>
             <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
               {/* Course Dates */}
               <div className="space-y-4 self-start">
@@ -162,6 +157,10 @@ export default function BitcoinForExecutivesPage() {
                     }))}
                   />
                 </Card>
+                {/* Price */}
+                <div className="mt-4">
+                  <div className="text-base font-semibold text-gray-700">CHF 5&apos;999.-</div>
+                </div>
               </div>
             </div>
 

--- a/src/app/education/financial-sovereignty/page.tsx
+++ b/src/app/education/financial-sovereignty/page.tsx
@@ -117,12 +117,6 @@ export default function FinancialSovereigntyPage() {
       <section className="swiss-section-sm bg-gray-50">
         <div className="swiss-grid">
           <div className="max-w-5xl mx-auto">
-            <div className="flex justify-center mb-10">
-              <div className="inline-block px-6 py-4 border-2 border-gray-200 rounded-xl bg-gray-50 text-center">
-                <div className="text-3xl font-bold text-gray-900 mb-1">CHF 749.-</div>
-                <div className="text-sm text-gray-600 font-medium">(CHF 50 in BTC incl.)</div>
-              </div>
-            </div>
             <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
               {/* Course Dates */}
               <div className="space-y-4 self-start">
@@ -156,6 +150,10 @@ export default function FinancialSovereigntyPage() {
                     }))}
                   />
                 </Card>
+                {/* Price */}
+                <div className="mt-4">
+                  <div className="text-base font-semibold text-gray-700">CHF 749.- <span className="font-normal text-gray-500">(CHF 50 in BTC incl.)</span></div>
+                </div>
               </div>
             </div>
 

--- a/src/app/education/private-bitcoin-briefing/page.tsx
+++ b/src/app/education/private-bitcoin-briefing/page.tsx
@@ -120,14 +120,6 @@ export default function PrivateBitcoinBriefingPage() {
       <section className="swiss-section bg-gray-50">
         <div className="swiss-grid">
           <div className="max-w-4xl mx-auto">
-            {/* Price */}
-            <div className="text-center mb-8">
-              <div className="inline-block p-6 border-2 border-gray-200 rounded-lg bg-gray-50">
-                <div className="text-3xl font-bold text-gray-900 mb-1">Price on inquiry</div>
-              </div>
-            </div>
-
-
             {/* Signup Form */}
             <div className="lg:col-span-2">
               <Card className="p-8 border-2 border-gray-200 bg-white">
@@ -139,6 +131,11 @@ export default function PrivateBitcoinBriefingPage() {
                   submitButtonText="Book a Discovery Call"
                 />
               </Card>
+            </div>
+
+            {/* Price */}
+            <div className="mt-4">
+              <div className="text-base font-semibold text-gray-700">Price on inquiry</div>
             </div>
 
           </div>

--- a/src/app/research/resq-package/page.tsx
+++ b/src/app/research/resq-package/page.tsx
@@ -56,13 +56,6 @@ export default function ResQPackagePage() {
       <section className="swiss-section bg-gray-50">
         <div className="swiss-grid">
           <div className="max-w-4xl mx-auto">
-            {/* Price */}
-            <div className="text-center mb-8">
-              <div className="inline-block p-6 border-2 border-gray-200 rounded-lg bg-gray-50">
-                <div className="text-3xl font-bold text-gray-900 mb-1">Price on inquiry</div>
-              </div>
-            </div>
-
             {/* Signup Form */}
             <div className="lg:col-span-2">
               <Card className="p-8 border-2 border-gray-200 bg-white">
@@ -74,6 +67,11 @@ export default function ResQPackagePage() {
                   submitButtonText="Request Research Quarterly"
                 />
               </Card>
+            </div>
+
+            {/* Price */}
+            <div className="mt-4">
+              <div className="text-base font-semibold text-gray-700">Price on inquiry</div>
             </div>
 
           </div>


### PR DESCRIPTION
Closes #111

## Changes

**Price tags** on all 4 offering pages: moved from above the booking/inquiry form to below it, left-aligned, and smaller font size.

**Domains page (/domains)**:
- Removed all "Read related article →" links from each domain entry
- Updated hero heading to "SBI Research Domains"
- Updated hero one-liner to new copy

Generated with [Claude Code](https://claude.ai/code)