### PR TITLE
Improve SBI offering findability and clean up price tags

### DIFF
--- a/src/app/education/bitcoin-for-executives/page.tsx
+++ b/src/app/education/bitcoin-for-executives/page.tsx
@@ -124,11 +124,6 @@ export default function BitcoinForExecutivesPage() {
       <section className="py-8 sm:py-10 bg-gray-50">
         <div className="swiss-grid">
           <div className="max-w-5xl mx-auto">
-            <div className="flex justify-center mb-10">
-              <div className="inline-block px-6 py-4 border-2 border-gray-200 rounded-xl bg-gray-50 text-center">
-                <div className="text-3xl font-bold text-gray-900 mb-1">CHF 5'999.-</div>
-              </div>
-            </div>
             <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
               {/* Course Dates */}
               <div className="space-y-4 self-start">
@@ -162,6 +157,8 @@ export default function BitcoinForExecutivesPage() {
                     }))}
                   />
                 </Card>
+                {/* Price */}
+                <div className="mt-4 text-sm text-gray-500">CHF 5'999.-</div>
               </div>
             </div>
 

--- a/src/app/education/financial-sovereignty/page.tsx
+++ b/src/app/education/financial-sovereignty/page.tsx
@@ -117,12 +117,6 @@ export default function FinancialSovereigntyPage() {
       <section className="swiss-section-sm bg-gray-50">
         <div className="swiss-grid">
           <div className="max-w-5xl mx-auto">
-            <div className="flex justify-center mb-10">
-              <div className="inline-block px-6 py-4 border-2 border-gray-200 rounded-xl bg-gray-50 text-center">
-                <div className="text-3xl font-bold text-gray-900 mb-1">CHF 749.-</div>
-                <div className="text-sm text-gray-600 font-medium">(CHF 50 in BTC incl.)</div>
-              </div>
-            </div>
             <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
               {/* Course Dates */}
               <div className="space-y-4 self-start">
@@ -156,6 +150,8 @@ export default function FinancialSovereigntyPage() {
                     }))}
                   />
                 </Card>
+                {/* Price */}
+                <div className="mt-4 text-sm text-gray-500">CHF 749.- <span className="text-gray-400">(CHF 50 in BTC incl.)</span></div>
               </div>
             </div>
 

--- a/src/app/education/private-bitcoin-briefing/page.tsx
+++ b/src/app/education/private-bitcoin-briefing/page.tsx
@@ -120,14 +120,6 @@ export default function PrivateBitcoinBriefingPage() {
       <section className="swiss-section bg-gray-50">
         <div className="swiss-grid">
           <div className="max-w-4xl mx-auto">
-            {/* Price */}
-            <div className="text-center mb-8">
-              <div className="inline-block p-6 border-2 border-gray-200 rounded-lg bg-gray-50">
-                <div className="text-3xl font-bold text-gray-900 mb-1">Price on inquiry</div>
-              </div>
-            </div>
-
-
             {/* Signup Form */}
             <div className="lg:col-span-2">
               <Card className="p-8 border-2 border-gray-200 bg-white">
@@ -139,6 +131,8 @@ export default function PrivateBitcoinBriefingPage() {
                   submitButtonText="Book a Discovery Call"
                 />
               </Card>
+              {/* Price */}
+              <div className="mt-4 text-sm text-gray-500">Price on inquiry</div>
             </div>
 
           </div>

--- a/src/app/research/page.tsx
+++ b/src/app/research/page.tsx
@@ -46,47 +46,11 @@ export default function ResearchPage() {
         </div>
       </section>
 
-      {/* Research Domains */}
-      <section className="swiss-section bg-gray-50">
-        <div className="swiss-grid">
-          <div className="text-center mb-12">
-            <div className="flex items-center justify-center mb-6">
-              <div className="swiss-blue-gradient-accent mx-auto"></div>
-            </div>
-            <h2>Six Research Domains</h2>
-            <p className="swiss-prose max-w-4xl mx-auto text-gray-600">
-              Our research spans six interconnected domains that capture Bitcoin's full strategic significance
-              for Switzerland's leadership in the global monetary system.
-            </p>
-          </div>
-
-          <div className="max-w-xl mx-auto">
-            <Link href="/domains" className="block group">
-              <img
-                src="/domain-circles/research-domains.png"
-                alt="Six Research Domains"
-                className="w-full h-auto transition-all duration-300 group-hover:scale-105"
-              />
-            </Link>
-          </div>
-        </div>
-      </section>
-
       {/* Research Offerings */}
       <section className="swiss-section bg-white border-t border-gray-100">
         <div className="swiss-grid">
           <div className="max-w-6xl mx-auto">
             <div className="flex flex-col">
-              <CourseSection
-                title="Bitcoin Intelligence Briefs"
-                description="For decision-makers who want substance over headlines, the SBI Fellows are writing dedicated Intelligence Briefs. Each Brief researches a specific Bitcoin issue in depth. Thus, each SBI domain receives expert analysis once a quarter. Currently available for free."
-                href="/research/intelligence-briefs"
-                details={briefsDetails}
-                image="/offerings-images/Intelligence-Briefs-Chemister-lab-ETHZ.jpg"
-                imageCredit="Chemistry Lab, ETH Zürich, 1954."
-                imageCreditUrl="http://doi.org/10.3932/ethz-a-000012924"
-              />
-
               <CourseSection
                 title="Bitcoin Research Quarterly"
                 description="For organisations and their clients who value concise, cross-domain fundamental Bitcoin research beyond the price chart. Original research, exclusive Fellow commentary, and news highlights are carefully curated using SBI's domain framework and distilled into a clear, forward-looking and actionable format."
@@ -95,9 +59,44 @@ export default function ResearchPage() {
                 image="/offerings-images/Research-Magazin-ETH-Library.jpg"
                 imageCredit="Magazin, ETH Library, 1975."
                 imageCreditUrl="http://doi.org/10.3932/ethz-a-000015361"
+              />
+
+              <CourseSection
+                title="Bitcoin Intelligence Briefs"
+                description="For decision-makers who want substance over headlines, the SBI Fellows are writing dedicated Intelligence Briefs. Each Brief researches a specific Bitcoin issue in depth. Thus, each SBI domain receives expert analysis once a quarter. Currently available for free."
+                href="/research/intelligence-briefs"
+                details={briefsDetails}
+                image="/offerings-images/Intelligence-Briefs-Chemister-lab-ETHZ.jpg"
+                imageCredit="Chemistry Lab, ETH Zürich, 1954."
+                imageCreditUrl="http://doi.org/10.3932/ethz-a-000012924"
                 reverse
               />
             </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Research Domains */}
+      <section className="swiss-section bg-gray-50">
+        <div className="swiss-grid">
+          <div className="text-center mb-12">
+            <div className="flex items-center justify-center mb-6">
+              <div className="swiss-blue-gradient-accent mx-auto"></div>
+            </div>
+            <h2>SBI Research Domains</h2>
+            <p className="swiss-prose max-w-4xl mx-auto text-gray-600">
+              Bitcoin's impact goes beyond money. We developed the SBI Domain Framework to give you a 360° view of Bitcoin's impact across sectors. Click the circle for more.
+            </p>
+          </div>
+
+          <div className="max-w-xl mx-auto">
+            <Link href="/domains" className="block group">
+              <img
+                src="/domain-circles/research-domains.png"
+                alt="SBI Research Domains"
+                className="w-full h-auto transition-all duration-300 group-hover:scale-105"
+              />
+            </Link>
           </div>
         </div>
       </section>

--- a/src/app/research/resq-package/page.tsx
+++ b/src/app/research/resq-package/page.tsx
@@ -44,9 +44,9 @@ export default function ResQPackagePage() {
         <div className="absolute inset-0 bg-white/80"></div>
         <div className="swiss-grid relative z-10">
           <div className="max-w-5xl mx-auto text-center">
-            <h1 className="mb-6 text-gray-900">Bitcoin Research Quarterly</h1>
+            <h1 className="mb-6 text-gray-900">Bitcoin Research Quarterly ('ResQ')</h1>
             <p className="swiss-prose-lg mb-12 max-w-4xl mx-auto text-gray-700 leading-relaxed">
-
+              Charts are only half the story. To make decisions you need more flesh to the bone. Our curated, fundamental Bitcoin research delivers what no chart can: arguments, context and background.
             </p>
           </div>
         </div>
@@ -56,13 +56,6 @@ export default function ResQPackagePage() {
       <section className="swiss-section bg-gray-50">
         <div className="swiss-grid">
           <div className="max-w-4xl mx-auto">
-            {/* Price */}
-            <div className="text-center mb-8">
-              <div className="inline-block p-6 border-2 border-gray-200 rounded-lg bg-gray-50">
-                <div className="text-3xl font-bold text-gray-900 mb-1">Price on inquiry</div>
-              </div>
-            </div>
-
             {/* Signup Form */}
             <div className="lg:col-span-2">
               <Card className="p-8 border-2 border-gray-200 bg-white">
@@ -74,6 +67,8 @@ export default function ResQPackagePage() {
                   submitButtonText="Request Research Quarterly"
                 />
               </Card>
+              {/* Price */}
+              <div className="mt-4 text-sm text-gray-500">Price on inquiry</div>
             </div>
 
           </div>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -25,8 +25,24 @@ const Header = () => {
   }, [dropdownOpen]);
 
   const navigation = [
-    { name: 'Education', href: '/education' },
-    { name: 'Research', href: '/research' },
+    {
+      name: 'Education',
+      href: '/education',
+      dropdown: [
+        { name: 'Private Bitcoin Briefing', href: '/education/private-bitcoin-briefing' },
+        { name: 'Bitcoin Executive Masterclass', href: '/education/bitcoin-for-executives' },
+        { name: 'Financial Sovereignty', href: '/education/financial-sovereignty' },
+      ]
+    },
+    {
+      name: 'Research',
+      href: '/research',
+      dropdown: [
+        { name: 'Bitcoin Intelligence Briefs', href: '/research/intelligence-briefs' },
+        { name: 'Bitcoin Research Quarterly', href: '/research/resq-package' },
+        { name: 'Research Domains', href: '/domains' },
+      ]
+    },
     { name: 'Speaking', href: '/speaking' },
     { name: 'Glossary', href: '/glossary' },
     {


### PR DESCRIPTION
Closes #118

- Add Education and Research dropdown sub-menus to navbar
- Restructure Research page: offerings above domains, ResQ first, rename domains section
- Update ResQ hero title and description
- Move price tags below form boxes, left-aligned and smaller

Generated with [Claude Code](https://claude.ai/code)