### PR TITLE
style: price tags in boxes with heading-style text (issue #111)

### DIFF
--- a/src/app/education/bitcoin-for-executives/page.tsx
+++ b/src/app/education/bitcoin-for-executives/page.tsx
@@ -158,7 +158,9 @@ export default function BitcoinForExecutivesPage() {
                   />
                 </Card>
                 {/* Price */}
-                <div className="mt-4 text-sm text-gray-500">CHF 5'999.-</div>
+                <Card className="mt-4 p-4 border-2 border-gray-200 bg-white">
+                  <span className="text-xl font-semibold text-gray-900">CHF 5&apos;999.-</span>
+                </Card>
               </div>
             </div>
 

--- a/src/app/education/financial-sovereignty/page.tsx
+++ b/src/app/education/financial-sovereignty/page.tsx
@@ -151,7 +151,10 @@ export default function FinancialSovereigntyPage() {
                   />
                 </Card>
                 {/* Price */}
-                <div className="mt-4 text-sm text-gray-500">CHF 749.- <span className="text-gray-400">(CHF 50 in BTC incl.)</span></div>
+                <Card className="mt-4 p-4 border-2 border-gray-200 bg-white">
+                  <span className="text-xl font-semibold text-gray-900">CHF 749.-</span>
+                  <span className="text-gray-400 text-sm ml-2">(CHF 50 in BTC incl.)</span>
+                </Card>
               </div>
             </div>
 

--- a/src/app/education/private-bitcoin-briefing/page.tsx
+++ b/src/app/education/private-bitcoin-briefing/page.tsx
@@ -132,7 +132,9 @@ export default function PrivateBitcoinBriefingPage() {
                 />
               </Card>
               {/* Price */}
-              <div className="mt-4 text-sm text-gray-500">Price on inquiry</div>
+              <Card className="mt-4 p-4 border-2 border-gray-200 bg-white">
+                <span className="text-xl font-semibold text-gray-900">Price on inquiry</span>
+              </Card>
             </div>
 
           </div>

--- a/src/app/research/resq-package/page.tsx
+++ b/src/app/research/resq-package/page.tsx
@@ -68,7 +68,9 @@ export default function ResQPackagePage() {
                 />
               </Card>
               {/* Price */}
-              <div className="mt-4 text-sm text-gray-500">Price on inquiry</div>
+              <Card className="mt-4 p-4 border-2 border-gray-200 bg-white">
+                <span className="text-xl font-semibold text-gray-900">Price on inquiry</span>
+              </Card>
             </div>
 
           </div>


### PR DESCRIPTION
Closes #111

## Changes

Price tags on all 4 offering pages are now wrapped in bordered `Card` components and styled with `text-xl font-semibold text-gray-900` to match the "Book your seat" heading style.

Generated with [Claude Code](https://claude.ai/code)